### PR TITLE
Refactor fixed points mode

### DIFF
--- a/src/Data.hpp
+++ b/src/Data.hpp
@@ -10,7 +10,7 @@ public:
   void write_hd_distribution(Result* result, float param = -1.0);
   void write_variety_distribution(Result* result, float param = -1.0);
   void write_variety_quantity(Result* result, float param = -1.0);
-  void write_fixed_points(Result* result, float param);
+  void write_final_state(Result* result, float param);
 private:
   fstream file;
   Parameter m_parameter;
@@ -109,7 +109,7 @@ void Data::write_variety_quantity(Result* result, float param){
   }
 }
 
-void Data::write_fixed_points(Result* result, float param){
+void Data::write_final_state(Result* result, float param){
   if(need_header){
     std::string header ("param; nVar; meanHD; totalPunctuation; ");
     header.append("productivityPunctuation; qualityPunctuation; ");

--- a/src/ModelRunner.hpp
+++ b/src/ModelRunner.hpp
@@ -81,10 +81,6 @@ void ModelRunner::run_var_param_fixed_points(char param){
 
   std::string param_str (1, param);
   Data fixed_points("varParamFixedPoints_" + param_str, parameter);
-  Data histogram_productivity("histogramProductivityVar_" + param_str, parameter);
-  Data hd_distribution("hdDistribution_" + param_str, parameter);
-  Data variety_distribution("varietyDistribution_" + param_str, parameter);
-  Data variety_quantity("varietyQuantity_" + param_str, parameter);
 
   std::vector<float> paramList = Parameter::get_parameter_variation(param);
 
@@ -94,23 +90,16 @@ void ModelRunner::run_var_param_fixed_points(char param){
     clock_t tStart = clock();
     Result result(parameter, 1);
     Result resultTemp;
-    result.numberVariety[0];
-    resultTemp.numberVariety.push_back(0);
 
     for(int run = 0; run < parameter.nRun; ++run){
       Model model(parameter);
       resultTemp = model.runFixedPoint();
-      result.sumResult(&resultTemp);
+      result.sumTemporal(&resultTemp);
     }
     cout << "Finish " << param << " = " << paramValue << ". ";
     cout << "Time taken: "<< (clock() - tStart)/CLOCKS_PER_SEC << "s." << endl;
 
     fixed_points.write_fixed_points(&result, paramValue);
-    histogram_productivity.write_histogram_productivity(&result, paramValue);
-    hd_distribution.write_hd_distribution(&result, paramValue);
-    variety_distribution.write_variety_distribution(&result, paramValue);
-    variety_quantity.write_variety_quantity(&result, paramValue);
-
   }
 }
 

--- a/src/ModelRunner.hpp
+++ b/src/ModelRunner.hpp
@@ -6,7 +6,7 @@ public:
   void run_standard(void);
   void run_plot(void);
   void run_var_param(char param, std::vector<float> paramList);
-  void run_var_param_fixed_points(char param);
+  void run_final_state(char param);
 private:
   void write_standard_results(Parameter parameter, Result* result);
 };
@@ -76,11 +76,11 @@ void ModelRunner::run_var_param(char param, std::vector<float> paramList){
   }
 }
 
-void ModelRunner::run_var_param_fixed_points(char param){
+void ModelRunner::run_final_state(char param){
   Parameter parameter;
 
   std::string param_str (1, param);
-  Data fixed_points("varParamFixedPoints_" + param_str, parameter);
+  Data final_state("finalStateVariation_" + param_str, parameter);
 
   std::vector<float> paramList = Parameter::get_parameter_variation(param);
 
@@ -93,13 +93,13 @@ void ModelRunner::run_var_param_fixed_points(char param){
 
     for(int run = 0; run < parameter.nRun; ++run){
       Model model(parameter);
-      resultTemp = model.runFixedPoint();
+      resultTemp = model.runFinalState();
       result.sumTemporal(&resultTemp);
     }
     cout << "Finish " << param << " = " << paramValue << ". ";
     cout << "Time taken: "<< (clock() - tStart)/CLOCKS_PER_SEC << "s." << endl;
 
-    fixed_points.write_fixed_points(&result, paramValue);
+    final_state.write_final_state(&result, paramValue);
   }
 }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -70,7 +70,7 @@ int main(int argc, char *argv[]){
       cout << "Running variation model fixed points, with variable ";
       cout << param << ". " << endl;
 
-      modelRunner.run_var_param_fixed_points(param);
+      modelRunner.run_final_state(param);
       break;
     }
     case 'm':{

--- a/src/model/Model.hpp
+++ b/src/model/Model.hpp
@@ -14,7 +14,7 @@ public:
   ~Model();
   Result runStandard(void);
   Result runPlot(void);
-  Result runFixedPoint(void);
+  Result runFinalState(void);
 };
 
 // Model constructor, receive model parameters, initialize then, and call for
@@ -88,7 +88,7 @@ Result Model::runStandard(void){
 
 // Run the model giving as output the final number of varieties and both
 // histograms
-Result Model::runFixedPoint(void){
+Result Model::runFinalState(void){
   Result result(m_parameter, household, ambient->grid);
 
   for(int t = 1; t < m_parameter.maxTime + 1; ++t)

--- a/src/model/Model.hpp
+++ b/src/model/Model.hpp
@@ -95,8 +95,6 @@ Result Model::runFixedPoint(void){
     iterate();
 
   result.save_timeline();
-  result.save_final_state();
-
   return result;
 }
 

--- a/src/model_helper/Result.hpp
+++ b/src/model_helper/Result.hpp
@@ -21,6 +21,8 @@ public:
   Result() = default;
   Result(Parameter t_parameter, int timeSize);
   Result(Parameter t_parameter, Household* t_household, Patch* t_grid);
+  void sumTemporal(Result* resultToSum);
+  void sumDistributions(Result* resultToSum);
   void sumResult(Result* resultToSum);
   void save_timeline();
   void save_final_state();
@@ -49,7 +51,7 @@ Result::Result(Parameter t_parameter, int timeSize)
 Result::Result(Parameter t_parameter, Household* t_household, Patch* t_grid)
   : metrics(t_parameter, t_household, t_grid) {}
 
-void Result::sumResult(Result* resultToSum){
+void Result::sumTemporal(Result* resultToSum){
   std::transform(numberVariety.begin(),
       numberVariety.end(), (*resultToSum).numberVariety.begin(),
       numberVariety.begin(), std::plus<int>());
@@ -62,12 +64,20 @@ void Result::sumResult(Result* resultToSum){
   sumResultElement(&bergerParkerCommunity, &((*resultToSum).bergerParkerCommunity));
   sumResultElement(&simpsonHD, &((*resultToSum).simpsonHD));
   sumResultElement(&shannonHD, &((*resultToSum).shannonHD));
+  sumResultElement(&bergerParkerHD, &((*resultToSum).bergerParkerHD));
+}
+
+void Result::sumDistributions(Result* resultToSum){
   sumResultElement(&varietyDistribution, &((*resultToSum).varietyDistribution));
   sumResultElement(&varietyQuantity, &((*resultToSum).varietyQuantity));
-  sumResultElement(&bergerParkerHD, &((*resultToSum).bergerParkerHD));
   sumResultElement(&productivityFrequency, &((*resultToSum).productivityFrequency));
   sumResultElement(&qualityFrequency, &((*resultToSum).qualityFrequency));
   sumResultElement(&hdDistribution, &((*resultToSum).hdDistribution));
+}
+
+void Result::sumResult(Result* resultToSum){
+  sumTemporal(resultToSum);
+  sumDistributions(resultToSum);
 }
 
 void Result::sumResultElement(std::vector<float>* v1, std::vector<float>* v2){

--- a/src/plot.jl
+++ b/src/plot.jl
@@ -52,8 +52,8 @@ function plotHandler(input_file)
     plotHistogramProductivity(df, output_file)
   elseif mode == "histogramProductivityVar"
     plotHistogramProductivityVar(df, output_file)
-  elseif mode == "varParamFixedPoints"
-    plotVarParamFixedPoints(df, output_file)
+  elseif mode == "finalStateVariation"
+    plotModelFinalStates(df, output_file)
   else
     println("$(input_file) is an invalid file.")
   end
@@ -275,7 +275,7 @@ function plotHistogramProductivityVar(df, output_file)
     println("Image $(output_file2) successfully generated.")
 end
 
-function plotVarParamFixedPoints(df, output_file)
+function plotModelFinalStates(df, output_file)
     param = string(output_file[end-4])
     p=plot(layer(df, x=:param, y=:nVar, Geom.line,
                      Theme(default_color=colorant"green")),


### PR DESCRIPTION
In order to prepare the code to the phase diagram mode some small updates in the fixed points mode are necessary. This PR makes the fixed point mode write only the final state variation and updates the fixed points name to final state.